### PR TITLE
fix: Correct references to repo after org move

### DIFF
--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: NVIDIA/NeMo-FW-CI-templates
+          repository: NVIDIA-NeMo/FW-CI-templates
           ref: v0.17.0
           path: send-slack-alert
 

--- a/.github/workflows/_code_freeze.yml
+++ b/.github/workflows/_code_freeze.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: NVIDIA/NeMo-FW-CI-templates
+          repository: NVIDIA-NeMo/FW-CI-templates
           ref: v0.17.0
           path: send-slack-alert
 

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -68,7 +68,7 @@ on:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.32.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.32.0
     with:
       dry-run: ${{ inputs.dry-run }}
       python-package: ${{ inputs.python-package }}
@@ -213,7 +213,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: NVIDIA/NeMo-FW-CI-templates
+          repository: NVIDIA-NeMo/FW-CI-templates
           ref: v0.17.0
           path: send-slack-alert
 

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -23,4 +23,4 @@ permissions:
 
 jobs:
   semantic-pull-request:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_semantic_pull_request.yml@v0.13.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_semantic_pull_request.yml@v0.13.0


### PR DESCRIPTION
Correct references to repo after org move