### PR TITLE
feat: Allow skipping the publish

### DIFF
--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -39,6 +39,11 @@ on:
         description: "Packaging tool (supported: setuptools, hatch, uv)"
         type: string
         default: setuptools
+      no-publish:
+        required: false
+        description: Do not publish the wheel
+        type: boolean
+        default: false
     secrets:
       TWINE_USERNAME:
         required: true
@@ -245,6 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.dry-run && 'public' || 'main' }}
+    if: inputs.no-publish == false
     steps:
       - name: Download wheel
         uses: actions/download-artifact@v4
@@ -285,7 +291,7 @@ jobs:
         with:
           message: >
             <${{ env.RUN_URL }}|Build, test, and push PyPi wheel (test)> has failed for <${{ env.COMMIT_URL }}|${{ env.COMMIT_SHA }}>.
-
+            
             cc: ${{ env.SLACK_WEBHOOK_ADMIN }}
 
 

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -53,6 +53,8 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
+      GH_TOKEN:
+        required: false
     outputs:
       version:
         description: NeMo library version
@@ -104,9 +106,16 @@ jobs:
 
       - name: Build wheel
         id: build
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           cd ${{ github.run_id }}
           ls -al
+
+          if [[ "$GH_TOKEN" != "" ]]; then
+            echo "machine github.com login x-access-token password $GH_TOKEN" > ~/.netrc
+            chmod 600 ~/.netrc
+          fi
 
           # Install the package to import and check the version in a later step
           if [[ "$PACKAGING" == "uv" ]]; then


### PR DESCRIPTION
Useful for running the pip-wheel and install workflow per commit w/o pushing to pypi each time.