### PR TITLE
feat: Update cherry-pick template to allow target-branches-pattern

### DIFF
--- a/.github/workflows/_cherry_pick.yml
+++ b/.github/workflows/_cherry_pick.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
     inputs:
       target-branches-pattern:
-        description: 'Regex pattern to match target branch names from PR labels'
+        description: 'Regex pattern to match target branches from PR labels'
         required: false
         default: 'r[0-9]+\.[0-9]+\.[0-9]+'
         type: string


### PR DESCRIPTION
feat: Update cherry-pick template to allow target-branches-pattern

Had to make this minor change because the recent merge was missing the semantic PR title.