### PR TITLE
feat: Detect deployment workflow

### DIFF
--- a/.github/workflows/_cicd_preflight.yml
+++ b/.github/workflows/_cicd_preflight.yml
@@ -35,6 +35,7 @@ jobs:
       force_run_all: ${{ steps.force_run_all.outputs.main }}
       docs_only: ${{ steps.docs_only.outputs.main == 'true' }}
       base_ref: ${{ steps.base-ref.outputs.base }}
+      is_deployment_workflow: ${{ steps.is-deployment-workflow.outputs.main == 'true'}}
     env:
       TESTS_TO_RUN: ${{ inputs.test_to_run }}
       EVENT_NAME: ${{ github.event_name }}
@@ -49,6 +50,12 @@ jobs:
         id: get-pr-info
         if: startsWith(github.ref, 'refs/heads/pull-request/')
         uses: nv-gha-runners/get-pr-info@main
+
+      - name: Is deployment workflow
+        id: is-deployment-workflow
+        if: startsWith(github.ref, 'refs/heads/deploy-release/')
+        run: |
+          echo "main=true" | tee -a "$GITHUB_OUTPUT"
 
       - name: Determine base reference
         id: base-ref


### PR DESCRIPTION
This detects whether the commit is meant for automated pass-through deployment. 

Such commits must be shipped to the protected branch `deploy-release/*` by the app `nemo-automation-bot` which will then allow to skip all compute heavy jobs