### PR TITLE
feat: Auto push version bump to target branch

### DIFF
--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -277,10 +277,6 @@ jobs:
             --title "beep boop 🤖: Bumping to v${{ steps.bump-version.outputs.version }}" \
             --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump-version.outputs.version }}." 
 
-          # TODO: Remove later
-          gh pr merge --auto --squash
-          # End
-
           CMD=$(echo -E 'gh pr merge --auto --squash')
 
           if [[ "$IS_DRY_RUN" == "true" ]]; then

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           cd ${{ github.run_id }}
 
-          TMP_BRANCH="deploy-to-main-$(uuidgen)"
+          TMP_BRANCH="deploy-release/$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
           git add ${{ inputs.python-package }}/package_info.py
           git commit -sS -m "chore: Version bump ${{ steps.bump-version.outputs.version }}" || echo "No changes to commit"

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -201,6 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test-publish-wheel, create-gh-release]
     if: ${{ needs.create-gh-release.outputs.is-release-candidate == 'true' }}
+    environment: main # ${{ inputs.dry-run == true && 'public' || 'main' }}
     env:
       IS_DRY_RUN: ${{ inputs.dry-run }}
     steps:

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Create tmp branch and push
         env:
-          GH_TOKEN: ${{ secrets.PAT }} # ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd ${{ github.run_id }}
 

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -90,6 +90,10 @@ on:
         required: true
       PAT:
         required: true
+      SSH_KEY:
+        required: false
+      SSH_PWD:
+        required: false
 
 jobs:
   build-test-publish-wheel:
@@ -196,9 +200,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ${{ github.run_id }}
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.release-ref }}
+
+      - name: Install GPG
+        if: secrets.SSH_KEY != '' && secrets.SSH_PWD != ''
+        run: sudo apt-get install -y gnupg2
+
+      - name: Import GPG key (for signing)
+        if: secrets.SSH_KEY != '' && secrets.SSH_PWD != ''
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        id: gpg-action
+        with:
+          gpg_private_key: ${{ secrets.SSH_KEY }}
+          passphrase: ${{ secrets.SSH_PWD }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
 
       - name: Bump version
         id: bump-version
@@ -217,20 +236,91 @@ jobs:
 
           echo "version=$MAJOR.$MINOR.$PATCH$NEXT_PRERELEASE.$NEXT_DEV" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Create Version Bump PR
-        uses: peter-evans/create-pull-request@v6
-        id: create-pull-request
-        if: ${{ inputs.dry-run != true }}
+      - name: Create tmp branch and push
+        run: |
+          TMP_BRANCH="deploy-to-main-$(uuidgen)"
+          git checkout -b "$TMP_BRANCH"
+          git add ${{ inputs.python-package }}/package_info.py
+          git commit -sS -m "chore: Version bump ${{ steps.bump-version.outputs.version }}" || echo "No changes to commit"
+          git push -u origin "$TMP_BRANCH"
+          echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
+
+      - name: Wait for status checks on tmp branch
+        uses: actions/github-script@v7
+        id: wait-status
         with:
-          path: ${{ github.run_id }}
-          branch: ci/bump-${{ steps.bump-version.outputs.version }}
-          title: "Version bump to `${{ steps.bump-version.outputs.version }}`"
-          body: |
-            🚀 Version bump ${{ inputs.library_name }} to `${{ steps.bump-version.outputs.version }}`
-          commit-message: "[🤖]: Howdy folks, let's bump ${{ inputs.library_name }} to `${{ steps.bump-version.outputs.version }}` !"
-          signoff: true
-          assignees: okoenig
-          base: ${{ inputs.version-bump-branch }}
+          github-token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = process.env.TMP_BRANCH;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Get latest commit SHA of branch
+            const { data: refData } = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `heads/${branch}`,  // note: no 'refs/' prefix here
+            });
+
+            const sha = refData.object.sha;
+
+            console.log(`Polling status for commit SHA: ${sha}`);
+
+            let checksPassed = false;
+            let maxAttempts = 30;
+            let attempt = 0;
+            const delay = ms => new Promise(res => setTimeout(res, ms));
+
+            while (!checksPassed && attempt < maxAttempts) {
+              attempt++;
+
+              // Use commit SHA instead of branch ref
+              const { data: status } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+
+              const allStatuses = status.statuses;
+              const allChecks = checks.check_runs;
+
+              if (allStatuses.length === 0 && allChecks.length === 0) {
+                console.log(`Attempt ${attempt}: No checks or statuses yet. Waiting...`);
+                await delay(10000);
+                continue;
+              }
+
+              const statusesOk = allStatuses.every(s => s.state === 'success');
+              const checksOk = allChecks.every(c => c.status === 'completed' && c.conclusion === 'success');
+
+              if (statusesOk && checksOk) {
+                console.log('✅ All checks passed.');
+                checksPassed = true;
+                break;
+              }
+
+              console.log(`Attempt ${attempt}: Checks not complete yet. Waiting...`);
+              await delay(10000);
+            }
+
+            if (!checksPassed) {
+              core.setFailed('❌ Status checks did not pass in time');
+            }
+
+      - name: Merge into target branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin ${{ inputs.version-bump-branch }}
+          git checkout ${{ inputs.version-bump-branch}}
+          git merge ${{ env.TMP_BRANCH }}
+          git push origin ${{ inputs.version-bump-branch }}
 
   notify:
     needs: [build-test-publish-wheel, create-gh-release]

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -277,7 +277,9 @@ jobs:
             --title "beep boop 🤖: Bumping to v${{ steps.bump-version.outputs.version }}" \
             --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump-version.outputs.version }}." 
 
-          CMD=$(echo -E 'gh pr merge --auto --squash')
+          # TODO: Remove later
+          gh pr merge --auto --squash
+          # End todo
 
           if [[ "$IS_DRY_RUN" == "true" ]]; then
             echo -E "$CMD"

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -261,85 +261,10 @@ jobs:
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 
-      - name: Wait for status checks on tmp branch
-        uses: actions/github-script@v7
-        id: wait-status
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const branch = process.env.TMP_BRANCH;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+          gh pr create --base ${{ inputs.version-bump-branch }} --head $TMP_BRANCH
 
-            // Get latest commit SHA of branch
-            const { data: refData } = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: `heads/${branch}`,  // note: no 'refs/' prefix here
-            });
 
-            const sha = refData.object.sha;
-
-            console.log(`Polling status for commit SHA: ${sha}`);
-
-            let checksPassed = false;
-            let maxAttempts = 30;
-            let attempt = 0;
-            const delay = ms => new Promise(res => setTimeout(res, ms));
-
-            while (!checksPassed && attempt < maxAttempts) {
-              attempt++;
-
-              // Use commit SHA instead of branch ref
-              const { data: status } = await github.rest.repos.getCombinedStatusForRef({
-                owner,
-                repo,
-                ref: sha,
-              });
-
-              const { data: checks } = await github.rest.checks.listForRef({
-                owner,
-                repo,
-                ref: sha,
-              });
-
-              const allStatuses = status.statuses;
-              const allChecks = checks.check_runs;
-
-              if (allStatuses.length === 0 && allChecks.length === 0) {
-                console.log(`Attempt ${attempt}: No checks or statuses yet. Waiting...`);
-                await delay(10000);
-                continue;
-              }
-
-              const statusesOk = allStatuses.every(s => s.state === 'success');
-              const checksOk = allChecks.every(c => c.status === 'completed' && c.conclusion === 'success');
-
-              if (statusesOk && checksOk) {
-                console.log('✅ All checks passed.');
-                checksPassed = true;
-                break;
-              }
-
-              console.log(`Attempt ${attempt}: Checks not complete yet. Waiting...`);
-              await delay(10000);
-            }
-
-            if (!checksPassed) {
-              core.setFailed('❌ Status checks did not pass in time');
-            }
-
-      - name: Merge into target branch
-        run: |
-          cd ${{ github.run_id }}
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin ${{ inputs.version-bump-branch }}
-          git checkout ${{ inputs.version-bump-branch}}
-          git merge ${{ env.TMP_BRANCH }}
-
-          CMD=$(echo -E 'git push origin ${{ inputs.version-bump-branch }}')
+          CMD=$(echo -E 'gh pr merge --auto --squash')
 
           if [[ "$IS_DRY_RUN" == "true" ]]; then
             echo -E "$CMD"

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -195,6 +195,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test-publish-wheel, create-gh-release]
     if: ${{ needs.create-gh-release.outputs.is-release-candidate == 'true' }}
+    env:
+      IS_DRY_RUN: ${{ inputs.dry-run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -320,7 +322,14 @@ jobs:
           git fetch origin ${{ inputs.version-bump-branch }}
           git checkout ${{ inputs.version-bump-branch}}
           git merge ${{ env.TMP_BRANCH }}
-          git push origin ${{ inputs.version-bump-branch }}
+
+          CMD=$(echo -E 'git push origin ${{ inputs.version-bump-branch }}')
+
+          if [[ "$IS_DRY_RUN" == "true" ]]; then
+            echo -E "$CMD"
+          else
+            eval "$CMD"
+          fi
 
   notify:
     needs: [build-test-publish-wheel, create-gh-release]

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test-publish-wheel, create-gh-release]
     if: ${{ needs.create-gh-release.outputs.is-release-candidate == 'true' }}
-    environment: main # ${{ inputs.dry-run == true && 'public' || 'main' }}
+    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
     env:
       IS_DRY_RUN: ${{ inputs.dry-run }}
     steps:

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -267,9 +267,7 @@ jobs:
             --base ${{ inputs.version-bump-branch }} \
             --head $TMP_BRANCH \
             --title "beep boop 🤖: Bumping to v${{ steps.bump-version.outputs.version }}" \
-            --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump-version.outputs.version }}." \
-            --label "automation" \
-            --label "release" 
+            --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump-version.outputs.version }}." 
 
           CMD=$(echo -E 'gh pr merge --auto --squash')
 

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -279,7 +279,9 @@ jobs:
 
           # TODO: Remove later
           gh pr merge --auto --squash
-          # End todo
+          # End
+
+          CMD=$(echo -E 'gh pr merge --auto --squash')
 
           if [[ "$IS_DRY_RUN" == "true" ]]; then
             echo -E "$CMD"

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -101,6 +101,10 @@ on:
       BOT_KEY:
         required: true
 
+permissions:
+  contents: write # To read repository content
+  pull-requests: write # To create PRs
+
 jobs:
   build-test-publish-wheel:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.48.0

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -79,6 +79,10 @@ on:
         description: Do not build the package in isolation
         type: boolean
         default: false
+      app-id:
+        required: true
+        description: GitHub App ID
+        type: string
     secrets:
       TWINE_USERNAME:
         required: true
@@ -94,6 +98,8 @@ on:
         required: false
       SSH_PWD:
         required: false
+      BOT_KEY:
+        required: true
 
 jobs:
   build-test-publish-wheel:
@@ -198,11 +204,17 @@ jobs:
     env:
       IS_DRY_RUN: ${{ inputs.dry-run }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.BOT_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           path: ${{ github.run_id }}
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.release-ref }}
@@ -259,7 +271,7 @@ jobs:
         uses: actions/github-script@v7
         id: wait-status
         with:
-          github-token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const branch = process.env.TMP_BRANCH;
             const owner = context.repo.owner;

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -231,6 +231,7 @@ jobs:
           passphrase: ${{ secrets.SSH_PWD }}
           git_user_signingkey: true
           git_commit_gpgsign: true
+          workdir: ${{ github.run_id }}
 
       - name: Bump version
         id: bump-version

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -220,17 +220,9 @@ jobs:
           ref: ${{ inputs.release-ref }}
 
       - name: Install GPG
-        env:
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_PWD: ${{ secrets.SSH_PWD }}
-        if: env.SSH_KEY != '' && env.SSH_PWD != ''
         run: sudo apt-get install -y gnupg2
 
       - name: Import GPG key (for signing)
-        env:
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_PWD: ${{ secrets.SSH_PWD }}
-        if: env.SSH_KEY != '' && env.SSH_PWD != ''
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         id: gpg-action
         with:

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -208,11 +208,17 @@ jobs:
           ref: ${{ inputs.release-ref }}
 
       - name: Install GPG
-        if: secrets.SSH_KEY != '' && secrets.SSH_PWD != ''
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_PWD: ${{ secrets.SSH_PWD }}
+        if: env.SSH_KEY != '' && env.SSH_PWD != ''
         run: sudo apt-get install -y gnupg2
 
       - name: Import GPG key (for signing)
-        if: secrets.SSH_KEY != '' && secrets.SSH_PWD != ''
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_PWD: ${{ secrets.SSH_PWD }}
+        if: env.SSH_KEY != '' && env.SSH_PWD != ''
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         id: gpg-action
         with:

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -251,6 +251,8 @@ jobs:
           echo "version=$MAJOR.$MINOR.$PATCH$NEXT_PRERELEASE.$NEXT_DEV" | tee -a "$GITHUB_OUTPUT"
 
       - name: Create tmp branch and push
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd ${{ github.run_id }}
 

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -246,6 +246,8 @@ jobs:
 
       - name: Create tmp branch and push
         run: |
+          cd ${{ github.run_id }}
+
           TMP_BRANCH="deploy-to-main-$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
           git add ${{ inputs.python-package }}/package_info.py
@@ -323,6 +325,8 @@ jobs:
 
       - name: Merge into target branch
         run: |
+          cd ${{ github.run_id }}
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin ${{ inputs.version-bump-branch }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -256,7 +256,7 @@ jobs:
 
       - name: Create tmp branch and push
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.PAT }} # ${{ steps.app-token.outputs.token }}
         run: |
           cd ${{ github.run_id }}
 

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -246,13 +246,17 @@ jobs:
           PATCH=$(cat ${{ inputs.python-package }}/package_info.py | awk '/^PATCH = /' | awk -F"= " '{print $2}')
           PRERELEASE=$(cat ${{ inputs.python-package }}/package_info.py | awk '/^PRE_RELEASE = /' | awk -F"= " '{print $2}' | tr -d '"' | tr -d "'")
 
-          NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
-          NEXT_DEV=dev0
+          if [[ "$PRERELEASE" != "" ]]; then
+            NEXT_PATCH=$PATCH
+            NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
+          else
+            NEXT_PATCH=$((${PATCH} + 1))
+            NEXT_PRERELEASE=$PRERELEASE
+          fi
 
-          sed -i "/^PRE_RELEASE/c\PRE_RELEASE = '$NEXT_PRERELEASE'" ${{ inputs.python-package }}/package_info.py
-          sed -i "/^DEV/c\DEV = '$NEXT_DEV'" ${{ inputs.python-package }}/package_info.py
+          sed -i "/^PRE_RELEASE/c\PRE_RELEASE = \"$NEXT_PRERELEASE\"" ${{ inputs.python-package }}/package_info.py
 
-          echo "version=$MAJOR.$MINOR.$PATCH$NEXT_PRERELEASE.$NEXT_DEV" | tee -a "$GITHUB_OUTPUT"
+          echo "version=$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE" | tee -a "$GITHUB_OUTPUT"
 
       - name: Create tmp branch and push
         env:

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -263,8 +263,13 @@ jobs:
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 
-          gh pr create --base ${{ inputs.version-bump-branch }} --head $TMP_BRANCH
-
+          gh pr create \
+            --base ${{ inputs.version-bump-branch }} \
+            --head $TMP_BRANCH \
+            --title "beep boop 🤖: Bumping to v${{ steps.bump-version.outputs.version }}" \
+            --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump-version.outputs.version }}." \
+            --label "automation" \
+            --label "release" 
 
           CMD=$(echo -E 'gh pr merge --auto --squash')
 


### PR DESCRIPTION
This PR allows the release workflow to push a version bump to the release branch.

It requires a GitHub App for authorization, since only automations shall be allowed to push to protected branches.

It also requires a PGP key since we want the bump commit to be signed.

It deploys the commit to a deployment branch `deploy-release/*` which only the bot is allowed to. On this deployment branch, status checks might be mocked so that the version bump takes place quickly. A PR is created so that we validate success of required status checks.

After all status check complete, the workflow merges the PR. 