### PR TITLE
feat: Update build-docs to support syncing all dependencies

### DIFF
--- a/.github/workflows/_build_docs.yml
+++ b/.github/workflows/_build_docs.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: boolean
         default: true
+      sync-all:
+        description: "Whether to sync all dependencies or just the docs"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   main:
@@ -48,7 +53,9 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          if [ -f "${{ inputs.requirements-file }}" ]; then
+          if [ "${{ inputs.sync-all }}" = "true" ]; then
+            uv sync --all-extras --all-groups
+          elif [ -f "${{ inputs.requirements-file }}" ]; then
             uv pip install -r ${{ inputs.requirements-file }}
           else
             uv sync --only-group docs


### PR DESCRIPTION
Update build-docs to support syncing all dependencies

The Emerging-Optimizers repo needs torch and other dependencies to be installed to build its docs. They are writing the sphinx docs such that it may reference torch objects along with installing the Emerging Optimizers package itself. So, this change provides an optional flag to sync all dependencies before building the docs.

Here is a successful build now in the now public repo:
https://github.com/NVIDIA-NeMo/Emerging-Optimizers/actions/runs/17884537073/job/50856508009?pr=14