### PR TITLE
feat: Update build_docs to release it

### DIFF
--- a/.github/workflows/_build_docs.yml
+++ b/.github/workflows/_build_docs.yml
@@ -31,7 +31,7 @@ on:
         type: boolean
         default: true
       sync-all:
-        description: "Whether to sync all dependencies or just the docs"
+        description: "Whether to sync all dependencies or just the docs group"
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
feat: Update build_docs to release it

Unfortunately the commit for this recent PR did not include `feat` in the title.  So, it's not deployed.  This is just a minor change to trigger the release on the repo.
https://github.com/NVIDIA-NeMo/FW-CI-templates/pull/267