### PR TITLE
fix(ci): avoid potential racing conditions 

### DIFF
--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -237,7 +237,7 @@ jobs:
             --base ${{ inputs.version-bump-branch }} \
             --head $TMP_BRANCH \
             --title "beep boop 🤖: Bumping ${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}" \
-            --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump-version.outputs.version }}."
+            --body "This is an automated PR to bump ${{ inputs.library-name }}:${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}."
 
       - name: Wait for status checks on tmp branch
         uses: actions/github-script@v7
@@ -313,16 +313,40 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin ${{ inputs.version-bump-branch }}
-          git checkout ${{ inputs.version-bump-branch }}
-          git merge ${{ env.TMP_BRANCH }}
 
           CMD=$(echo -E 'git push origin ${{ inputs.version-bump-branch }}')
 
           if [[ "$IS_DRY_RUN" == "true" ]]; then
-            echo "$CMD"
+            echo "dry-run enabled, would have run: $CMD"
           else
-            eval "$CMD"
+            # Here we account for potential race conditions from multiple concurrent releases.
+            # Those can be legit (operating on different packages within the monorepo, for example)
+            # but the pushes would be still rejected purely because of git's inability to
+            # push non-fast-forward updates to the branch. In this case we would need to let
+            # a retry.
+            git fetch origin ${{ inputs.version-bump-branch }}
+            git checkout ${{ inputs.version-bump-branch }}
+            git merge ${{ env.TMP_BRANCH }}
+
+            for attempt in {1..3}; do
+              if eval "$CMD"; then
+                echo "Git push succeeded on attempt $attempt"
+                break
+              else
+                echo "Git push failed on attempt $attempt"
+                if [[ $attempt -lt 3 ]]; then
+                  sleep 2
+                  # We refetch, reset and re-merge. Note resetting because the local
+                  # branch is "contaminated" with previous merge attempt.
+                  git fetch origin ${{ inputs.version-bump-branch }}
+                  git reset --hard origin/${{ inputs.version-bump-branch }}
+                  git merge ${{ env.TMP_BRANCH }}
+                else
+                  echo "Git push failed after 3 attempts"
+                  exit 1
+                fi
+              fi
+            done
           fi
 
       - name: Delete ${{ env.TMP_BRANCH }} branch

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -216,6 +216,7 @@ jobs:
 
       - name: Create and push deployment branch
         env:
+          PYPROJECT_NAME: ${{ inputs.python-package }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd ${{ github.run_id }}
@@ -226,7 +227,7 @@ jobs:
           TMP_BRANCH="deploy-release/$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
           git add $PACKAGE_INFO_FILE
-          git commit -sS -m "beep boop 🤖: Bumping to v${{ steps.bump-version.outputs.version }}" || echo "No changes to commit"
+          git commit -sS -m "beep boop 🤖: Bumping ${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}" || echo "No changes to commit"
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 
@@ -235,7 +236,7 @@ jobs:
           gh pr create \
             --base ${{ inputs.version-bump-branch }} \
             --head $TMP_BRANCH \
-            --title "beep boop 🤖: Bumping to v${{ steps.bump-version.outputs.version }}" \
+            --title "beep boop 🤖: Bumping ${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}" \
             --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump-version.outputs.version }}."
 
       - name: Wait for status checks on tmp branch

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -335,7 +335,7 @@ jobs:
               else
                 echo "Git push failed on attempt $attempt"
                 if [[ $attempt -lt 3 ]]; then
-                  sleep 2
+                  sleep $((RANDOM % 3 + 1))
                   # We refetch, reset and re-merge. Note resetting because the local
                   # branch is "contaminated" with previous merge attempt.
                   git fetch origin ${{ inputs.version-bump-branch }}


### PR DESCRIPTION
This allows up to three retries to push the bump in the light of irreducible potential concurrency in monorepos