### PR TITLE
fix: Fix secret detector to work with forks

### DIFF
--- a/.github/workflows/_secrets-detector.yml
+++ b/.github/workflows/_secrets-detector.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ${{ github.run_id }}
-          ref: ${{ inputs.branch-name || github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Install secrets detector


### PR DESCRIPTION
fix: Fix secret detector to work with forks

With a fork, the `github.head_ref` resolves to a branch on the fork that the GHA cannot checkout
https://github.com/NVIDIA-NeMo/Emerging-Optimizers/actions/runs/17986485490/job/51165838746?pr=16

So, this uses the head.sha which seems to work.
https://github.com/NVIDIA-NeMo/Emerging-Optimizers/actions/runs/17995620322/job/51194260174
