### PR TITLE
fix: Check-imports

### DIFF
--- a/.github/actions/check-imports/action.yml
+++ b/.github/actions/check-imports/action.yml
@@ -31,4 +31,6 @@ runs:
 
     - name: Check imports
       shell: bash -x -e -u -o pipefail {0}
-      run: ${{ inputs.python-binary }} ${GITHUB_ACTION_PATH}/check_imports.py --package-name ${{ inputs.package-name }}
+      run: |
+        cd /tmp # Move into another dir to avoid local import
+        ${{ inputs.python-binary }} ${GITHUB_ACTION_PATH}/check_imports.py --package-name ${{ inputs.package-name }}


### PR DESCRIPTION
Point of this action to check if the installed wheel is importable. By not cd'ing out of the current workdir, we're potentially checking the local project instead of the one in site-packages.